### PR TITLE
Fix: various errors during installation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,8 @@
 # pylint: disable=missing-docstring, broad-except
-import subprocess
 import os
 import platform
+import subprocess
+import sys
 import sysconfig
 
 import setuptools
@@ -12,11 +13,11 @@ with open("README.md", "r") as fh:
 
 uplinkc_version = "v1.2.2"
 
-class Install(install):
 
+class Install(install):
     @staticmethod
     def find_module_path():
-        new_path = os.path.join(sysconfig.get_paths()['purelib'], "uplink_python")
+        new_path = os.path.join(sysconfig.get_paths()["purelib"], "uplink_python")
         try:
             os.makedirs(new_path, exist_ok=True)
             os.system("echo Directory uplink_python created successfully.")
@@ -25,35 +26,29 @@ class Install(install):
         return new_path
 
     def run(self):
-
         try:
             install_path = self.find_module_path()
-            os.system("echo Package installation path: " + install_path)
-            if platform.system() == "Windows":
-                os.system("icacls " + install_path + " /grant Everyone:F /t")
-            else:
-                os.system("sudo chmod -R 777 " + install_path)
-            os.system("echo Building libuplinkc.so")
+            print("Package installation path: " + install_path)
+            print("Building libuplinkc.so")
             copy_command = "copy" if platform.system() == "Windows" else "cp"
-            command = "git clone  -b "+uplinkc_version+ "https://github.com/storj/uplink-c && cd uplink-c" \
-                      "&& go build -o libuplinkc.so -buildmode=c-shared" \
-                      "&& " + copy_command + " *.so " + install_path
-            build_so = subprocess.Popen(command,
-                                        stdout=subprocess.PIPE,
-                                        stderr=subprocess.STDOUT, shell=True)
+            command = (
+                f"git clone -c advice.detachedHead=false -b {uplinkc_version} https://github.com/storj/uplink-c"
+                f"&& cd uplink-c && go build -o libuplinkc.so -buildmode=c-shared"
+                f"&& {copy_command}  *.so {install_path}"
+            )
+            build_so = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, shell=True)
             output, errors = build_so.communicate()
             build_so.wait()
-            if output is not None:
-                os.system("echo " + output.decode('utf-8'))
-                os.system("echo Building libuplinkc.so successful.")
-            if errors is not None:
-                os.system("echo " + errors.decode('utf-8'))
-                os.system("echo Building libuplinkc.so failed.")
+            if output:
+                print(output.decode("utf-8"))
+                print("Building libuplinkc.so successful.")
+            if errors:
+                print(errors.decode("utf-8"))
+                print("Building libuplinkc.so failed.")
             if build_so.returncode != 0:
-                os.exit(1)
+                sys.exit(1)
         except Exception as error:
-            os.system("echo " + str(error))
-            os.system("echo Building libuplinkc.so failed.")
+            print("Building libuplinkc.so failed: " + str(error))
 
         install.run(self)
 
@@ -63,15 +58,13 @@ setuptools.setup(
     version="1.2.2.0",
     author="Utropicmedia",
     author_email="development@utropicmedia.com",
-    license='Apache Software License',
-    description="Python-native language binding for uplink to "
-                "communicate with the Storj network.",
+    license="Apache Software License",
+    description="Python-native language binding for uplink to " "communicate with the Storj network.",
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/storj-thirdparty/uplink-python",
-
-    packages=['uplink_python'],
-    install_requires=['wheel'],
+    packages=["uplink_python"],
+    install_requires=["wheel"],
     include_package_data=True,
     classifiers=[
         "Intended Audience :: Developers",
@@ -80,8 +73,8 @@ setuptools.setup(
         "Operating System :: OS Independent",
         "Topic :: Software Development :: Build Tools",
     ],
-    python_requires='>=3.4',
+    python_requires=">=3.4",
     cmdclass={
-        'install': Install,
-    }
+        "install": Install,
+    },
 )


### PR DESCRIPTION
1. Add Missing space before the git url. This problem causes git clone failure, so the whole share object building process doesn't work.

1. Remove `sudo` statements. If the package path is not writable to current user, then it should not be. We should let user to decide whether to use `sudo` instead of prompt password in the middle of installing (Actually install to system site-packages with admin privilege is a bad practice). Also, if user is using virtualenv or install with `--user`, it's perfectly fine without `sudo`.

1. Avoid echoing the output because system output is unpredictable. It could be multiple lines, so `os.system("echo ", output.decode("utf-8"))` could end up executing the following shell command

    ```bash
    echo the first line
    the second line
    the third line
    ```

    `the second line` and `the third line` will be executed as normal shell command.

    We don't need to use echo to print out the result.

1. `os.exit(1)` should be `sys.exit(1)`


